### PR TITLE
Gemini provider fix, Fix mentions to paketerix, Update template's flake.lock

### DIFF
--- a/.github/workflows/train-on-dataset.yml
+++ b/.github/workflows/train-on-dataset.yml
@@ -76,13 +76,13 @@ jobs:
         
       # Dependencies are handled by nix develop, so we don't need to install them separately
           
-      - name: Setup paketerix configuration
+      - name: Setup packagerix configuration
         run: |
           # Create config directory
           mkdir -p ~/.packagerix
           
           # Set Anthropic API key as environment variable
-          # (paketerix will pick it up from env vars as fallback)
+          # (packagerix will pick it up from env vars as fallback)
           echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> $GITHUB_ENV
           
           # Create model configuration file
@@ -102,7 +102,7 @@ jobs:
           # Create output directory for this run
           mkdir -p output
           
-          # Run paketerix with raw output and save results
+          # Run packagerix with raw output and save results
           nix develop .# -c python -m packagerix \
             --raw \
             --output-dir output \
@@ -132,7 +132,7 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: paketerix-output-${{ matrix.issue_number }}
+          name: packagerix-output-${{ matrix.issue_number }}
           path: |
             output_${{ matrix.issue_number }}.log
             error_${{ matrix.issue_number }}.log
@@ -171,7 +171,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: paketerix-output-*
+          pattern: packagerix-output-*
           
       - name: Aggregate results
         run: |
@@ -182,9 +182,9 @@ jobs:
           success=0
           failed=0
           
-          for dir in artifacts/paketerix-output-*; do
+          for dir in artifacts/packagerix-output-*; do
             if [ -d "$dir" ]; then
-              issue_num=$(basename "$dir" | sed 's/paketerix-output-//')
+              issue_num=$(basename "$dir" | sed 's/packagerix-output-//')
               total=$((total + 1))
               
               # Check if there's a package.nix file in the output directory

--- a/src/packagerix/template/flake.lock
+++ b/src/packagerix/template/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {

--- a/src/packagerix/ui/model_config.py
+++ b/src/packagerix/ui/model_config.py
@@ -34,11 +34,11 @@ PROVIDERS = [
         setup_url="https://platform.openai.com/"
     ),
     Provider(
-        name="google",
+        name="gemini",
         display_name="Gemini",
         env_var="GEMINI_API_KEY",
         requires_api_key=True,
-        setup_url="https://makersuite.google.com/"
+        setup_url="https://aistudio.google.com/"
     ),
     Provider(
         name="ollama",
@@ -81,8 +81,6 @@ def get_available_models(provider: Provider) -> List[str]:
         # Add provider prefix to all models for LiteLLM
         if provider.name == "ollama":
             return [f"ollama/{model}" for model in models]
-        elif provider.name == "google":
-            return [f"gemini/{model}" for model in models]
         else:
             # Anthropic and OpenAI models typically don't need prefixes
             return models


### PR DESCRIPTION
Sorry for joining all these 3 commits into a single pull-request, didn't know if I could split them later into different PRs or not.
TLDR all simple changes

- Rename google provider to gemini and remove unnecessary addition of "gemini" before each model name
- Rename paketerix mentions in github workflow to packagerix
- Update the template's flake.lock